### PR TITLE
Migrate to stable ewasy shim & make deployment easier

### DIFF
--- a/samples/helloworld/Makefile
+++ b/samples/helloworld/Makefile
@@ -25,31 +25,51 @@
 # For more information, please refer to <http://unlicense.org/>
 #
 
-GOPATH ?= $(HOME)/go
 HANDLER ?= handler
-PACKAGE ?= package
+PACKAGE ?= $(HANDLER)
+GOPATH  ?= $(HOME)/go
 
-all:
-	@docker run --rm \
-		-v $(GOPATH):/go -v $(CURDIR):/tmp \
-		-e "HANDLER=$(HANDLER)" -e "PACKAGE=$(PACKAGE)" \
-		eawsy/aws-lambda-go-shim make _all
+WORKDIR = $(CURDIR:$(GOPATH)%=/go%)
+ifeq ($(WORKDIR),$(CURDIR))
+	WORKDIR = /tmp
+endif
 
-clean: _clean
+ROLE_ARN=`aws iam get-role --role-name lambda_basic_execution --query 'Role.Arn' --output text`
 
-push:
-	aws lambda update-function-code --function-name HelloWorld --zip-file fileb://package.zip
+docker:
+	@docker run --rm                                                             \
+	  -e HANDLER=$(HANDLER)                                                      \
+	  -e PACKAGE=$(PACKAGE)                                                      \
+	  -v $(GOPATH):/go                                                           \
+	  -v $(CURDIR):/tmp                                                          \
+	  -w $(WORKDIR)                                                              \
+	  eawsy/aws-lambda-go-shim:latest make all
 
-_all: _clean
-	@echo -ne "build..."\\r
+all: build pack perm
+
+build:
 	@go build -buildmode=plugin -ldflags='-w -s' -o $(HANDLER).so
-	@chown $(shell stat -c '%u:%g' .) $(HANDLER).so
-	@echo -ne "build, pack"\\r
-	@zip -q $(PACKAGE).zip $(HANDLER).so
-	@echo -ne "build, pack, inject"\\r
-	@cd /; mv /shim $(HANDLER); zip -q -r /tmp/$(PACKAGE).zip $(HANDLER)
-	@chown $(shell stat -c '%u:%g' .) $(PACKAGE).zip
-	@echo -ne "build, pack, inject, go!"\\n
 
-_clean:
-	@rm -rf $(PACKAGE).zip $(HANDLER).so
+pack:
+	@pack $(HANDLER) $(HANDLER).so $(PACKAGE).zip
+
+perm:
+	@chown $(shell stat -c '%u:%g' .) $(HANDLER).so $(PACKAGE).zip
+
+clean:
+	@rm -rf $(HANDLER) $(HANDLER).so $(PACKAGE).zip
+
+create:
+	@aws lambda create-function                                                  \
+	  --function-name HelloAlexa                                                 \
+	  --zip-file fileb://handler.zip                                             \
+	  --role $(ROLE_ARN)                                                         \
+	  --runtime python2.7                                                        \
+	  --handler handler.Handle
+
+update:
+	@aws lambda update-function-code                                             \
+	  --function-name HelloAlexa                                                 \
+	  --zip-file fileb://handler.zip
+
+.PHONY: docker all build pack perm clean create update

--- a/samples/helloworld/README.md
+++ b/samples/helloworld/README.md
@@ -4,11 +4,12 @@ This SDK was designed to be used as an AWS Lambda function via the [eawsy lambda
 documentation and install the necessary dependencies if you will be deploying
 this sample to AWS Lambda.
 
-This also assumes you have the [Amazon AWS CLI](https://aws.amazon.com/cli/) installed and configured.
+This also assumes you have the [Amazon AWS CLI](https://aws.amazon.com/cli/) installed and configured. You should also have the "lambda_basic_execution"
+role.
 
 First, create an Alexa Skill following the instructions described in the [Java HelloWorld Sample](https://github.com/amzn/alexa-skills-kit-java/tree/master/samples/src/main/java/helloworld)
 
-Second, compile the sample using the included Makefile
+Second, retrieve dependencies
 
 ```
 docker pull eawsy/aws-lambda-go-shim:latest
@@ -16,22 +17,24 @@ go get -u -d github.com/eawsy/aws-lambda-go-core/...
 go get -u github.com/ericdaugherty/alexa-skills-kit-golang
 ```
 
-Then, create a new Lambda function using the AWS CLI:
+Third, compile the sample using the included Makefile
 
 ```
-aws lambda create-function \
-  --role arn:aws:iam::AWS_ACCOUNT_NUMBER:role/lambda_basic_execution \
-  --function-name HelloWorld \
-  --zip-file fileb://handler.zip \
-  --runtime python2.7 \
-  --handler handler.Handle
+make
 ```
 
-You can now test the HelloWorld skill via an Echo attached to your Amazon account or using the Amazon Alexa Console.
+Then, create a new Lambda function using the included Makefile:
 
-Once the lambda function is created, you can use the make file to build and
+```
+make create
+```
+
+You can now test the HelloAlexa skill via an Echo attached to your Amazon account or using the Amazon Alexa Console.
+
+Once the lambda function is created, you can use the Makefile to build and
 update your function.
 
 ```
-make all push
+make
+make update
 ```

--- a/samples/helloworld/README.md
+++ b/samples/helloworld/README.md
@@ -11,7 +11,9 @@ First, create an Alexa Skill following the instructions described in the [Java H
 Second, compile the sample using the included Makefile
 
 ```
-make all
+docker pull eawsy/aws-lambda-go-shim:latest
+go get -u -d github.com/eawsy/aws-lambda-go-core/...
+go get -u github.com/ericdaugherty/alexa-skills-kit-golang
 ```
 
 Then, create a new Lambda function using the AWS CLI:
@@ -20,7 +22,7 @@ Then, create a new Lambda function using the AWS CLI:
 aws lambda create-function \
   --role arn:aws:iam::AWS_ACCOUNT_NUMBER:role/lambda_basic_execution \
   --function-name HelloWorld \
-  --zip-file fileb://package.zip \
+  --zip-file fileb://handler.zip \
   --runtime python2.7 \
   --handler handler.Handle
 ```

--- a/samples/helloworld/handler.go
+++ b/samples/helloworld/handler.go
@@ -1,9 +1,5 @@
 package main
 
-//TODO Need to be main?  Breaks as helloworld
-
-import "C"
-
 import (
 	"errors"
 	"log"


### PR DESCRIPTION
- Migrate to the latest release of the shim.
- Eliminate 'import "C"' statement (no more needed)
- No main() needed, it's a Go 1.8 plugin
- Update Makefile to that of upstream
- Update Makefile to ease Lambda creation and deployment
- Update README to reflect these changes
