### PR TITLE
Added context to all Request handler methods

### DIFF
--- a/alexa.go
+++ b/alexa.go
@@ -27,10 +27,10 @@ type Alexa struct {
 // RequestHandler defines the interface that must be implemented to handle
 // Alexa Requests
 type RequestHandler interface {
-	OnSessionStarted(*context.Context, *Request, *Session, *Response) error
-	OnLaunch(*context.Context, *Request, *Session, *Response) error
-	OnIntent(*context.Context, *Request, *Session, *Response) error
-	OnSessionEnded(*context.Context, *Request, *Session, *Response) error
+	OnSessionStarted(context.Context, *Request, *Session, *Response) error
+	OnLaunch(context.Context, *Request, *Session, *Response) error
+	OnIntent(context.Context, *Request, *Session, *Response) error
+	OnSessionEnded(context.Context, *Request, *Session, *Response) error
 }
 
 // RequestEnvelope contains the data passed from Alexa to the request handler.
@@ -153,7 +153,7 @@ type DialogDirective struct {
 }
 
 // ProcessRequest handles a request passed from Alexa
-func (alexa *Alexa) ProcessRequest(context *context.Context, requestEnv *RequestEnvelope) (*ResponseEnvelope, error) {
+func (alexa *Alexa) ProcessRequest(context context.Context, requestEnv *RequestEnvelope) (*ResponseEnvelope, error) {
 
 	if !alexa.IgnoreApplicationID {
 		err := alexa.verifyApplicationID(requestEnv)

--- a/alexa.go
+++ b/alexa.go
@@ -1,6 +1,7 @@
 package alexa
 
 import (
+	"context"
 	"errors"
 	"log"
 	"math"
@@ -26,10 +27,10 @@ type Alexa struct {
 // RequestHandler defines the interface that must be implemented to handle
 // Alexa Requests
 type RequestHandler interface {
-	OnSessionStarted(*Request, *Session, *Response) error
-	OnLaunch(*Request, *Session, *Response) error
-	OnIntent(*Request, *Session, *Response) error
-	OnSessionEnded(*Request, *Session, *Response) error
+	OnSessionStarted(*context.Context, *Request, *Session, *Response) error
+	OnLaunch(*context.Context, *Request, *Session, *Response) error
+	OnIntent(*context.Context, *Request, *Session, *Response) error
+	OnSessionEnded(*context.Context, *Request, *Session, *Response) error
 }
 
 // RequestEnvelope contains the data passed from Alexa to the request handler.
@@ -152,7 +153,7 @@ type DialogDirective struct {
 }
 
 // ProcessRequest handles a request passed from Alexa
-func (alexa *Alexa) ProcessRequest(requestEnv *RequestEnvelope) (*ResponseEnvelope, error) {
+func (alexa *Alexa) ProcessRequest(context *context.Context, requestEnv *RequestEnvelope) (*ResponseEnvelope, error) {
 
 	if !alexa.IgnoreApplicationID {
 		err := alexa.verifyApplicationID(requestEnv)
@@ -181,7 +182,7 @@ func (alexa *Alexa) ProcessRequest(requestEnv *RequestEnvelope) (*ResponseEnvelo
 
 	// If it is a new session, invoke onSessionStarted
 	if session.New {
-		err := alexa.RequestHandler.OnSessionStarted(request, session, response)
+		err := alexa.RequestHandler.OnSessionStarted(context, request, session, response)
 		if err != nil {
 			log.Println("Error handling OnSessionStarted.", err.Error())
 			return nil, err
@@ -190,19 +191,19 @@ func (alexa *Alexa) ProcessRequest(requestEnv *RequestEnvelope) (*ResponseEnvelo
 
 	switch requestEnv.Request.Type {
 	case launchRequestName:
-		err := alexa.RequestHandler.OnLaunch(request, session, response)
+		err := alexa.RequestHandler.OnLaunch(context, request, session, response)
 		if err != nil {
 			log.Println("Error handling OnLaunch.", err.Error())
 			return nil, err
 		}
 	case intentRequestName:
-		err := alexa.RequestHandler.OnIntent(request, session, response)
+		err := alexa.RequestHandler.OnIntent(context, request, session, response)
 		if err != nil {
 			log.Println("Error handling OnIntent.", err.Error())
 			return nil, err
 		}
 	case sessionEndedRequestName:
-		err := alexa.RequestHandler.OnSessionEnded(request, session, response)
+		err := alexa.RequestHandler.OnSessionEnded(context, request, session, response)
 		if err != nil {
 			log.Println("Error handling OnSessionEnded.", err.Error())
 			return nil, err

--- a/alexa_test.go
+++ b/alexa_test.go
@@ -81,26 +81,26 @@ func TestAlexaAppIDValidation(t *testing.T) {
 
 	alexa := getAlexa()
 	ctx := context.Background()
-	_, err := alexa.ProcessRequest(&ctx, request)
+	_, err := alexa.ProcessRequest(ctx, request)
 	if err != nil {
 		t.Error("Expected ProcessRequest to succeed but got error", err)
 	}
 
 	alexa = &Alexa{ApplicationID: "amzn1.ask.skill.ABC123456", RequestHandler: &emptyRequestHandler{}}
-	_, err = alexa.ProcessRequest(&ctx, request)
+	_, err = alexa.ProcessRequest(ctx, request)
 	if err == nil {
 		t.Error("Expected ProcessRequest to fail due to invalid Application ID but no err was returned.")
 	}
 
 	alexa = &Alexa{ApplicationID: "", RequestHandler: &emptyRequestHandler{}}
-	_, err = alexa.ProcessRequest(&ctx, request)
+	_, err = alexa.ProcessRequest(ctx, request)
 	if err == nil {
 		t.Error("Expected ProcessRequest to fail due to an empty Application ID but no err was returned.")
 	}
 
 	alexa = &Alexa{ApplicationID: applicationID, RequestHandler: &emptyRequestHandler{}}
 	request.Session.Application.ApplicationID = ""
-	_, err = alexa.ProcessRequest(&ctx, request)
+	_, err = alexa.ProcessRequest(ctx, request)
 	if err == nil {
 		t.Error("Expected ProcessRequest to fail due to an empty Request Application ID but no err was returned.")
 	}
@@ -113,27 +113,27 @@ func TestAlexaTimestampValidation(t *testing.T) {
 	duration, _ := time.ParseDuration("-145s")
 	request.Request.Timestamp = time.Now().Add(duration).Format(time.RFC3339)
 	ctx := context.Background()
-	_, err := alexa.ProcessRequest(&ctx, request)
+	_, err := alexa.ProcessRequest(ctx, request)
 	if err != nil {
 		t.Error("Expected ProcessRequest to succeed but got error", err)
 	}
 
 	duration, _ = time.ParseDuration("-151s")
 	request.Request.Timestamp = time.Now().Add(duration).Format(time.RFC3339)
-	_, err = alexa.ProcessRequest(&ctx, request)
+	_, err = alexa.ProcessRequest(ctx, request)
 	if err == nil {
 		t.Error("Expected ProcessRequest to fail to due to an invalid timetamp but no err was returned.")
 	}
 
 	duration, _ = time.ParseDuration("151s")
 	request.Request.Timestamp = time.Now().Add(duration).Format(time.RFC3339)
-	_, err = alexa.ProcessRequest(&ctx, request)
+	_, err = alexa.ProcessRequest(ctx, request)
 	if err == nil {
 		t.Error("Expected ProcessRequest to fail to due to an invalid timetamp but no err was returned.")
 	}
 
 	request.Request.Timestamp = "UNPARSEABLE"
-	_, err = alexa.ProcessRequest(&ctx, request)
+	_, err = alexa.ProcessRequest(ctx, request)
 	if err == nil {
 		t.Error("Expected ProcessRequest to fail because the timestamp could not be parsed but no err was returned")
 	}
@@ -141,7 +141,7 @@ func TestAlexaTimestampValidation(t *testing.T) {
 	alexa.SetTimestampTolerance(0)
 	duration, _ = time.ParseDuration("-1s")
 	request.Request.Timestamp = time.Now().Add(duration).Format(time.RFC3339)
-	_, err = alexa.ProcessRequest(&ctx, request)
+	_, err = alexa.ProcessRequest(ctx, request)
 	alexa.SetTimestampTolerance(150)
 	if err == nil {
 		t.Error("Expected ProcessRequest to fail to due to an invalid timetamp but no err was returned.")
@@ -151,7 +151,7 @@ func TestAlexaTimestampValidation(t *testing.T) {
 	duration, _ = time.ParseDuration("151s")
 	request.Request.Timestamp = time.Now().Add(duration).Format(time.RFC3339)
 	alexa.IgnoreTimestamp = true
-	_, err = alexa.ProcessRequest(&ctx, request)
+	_, err = alexa.ProcessRequest(ctx, request)
 	if err != nil {
 		t.Error("Expected ProcessRequest to pass even with an invalid timestamp because validation is disabled.")
 	}
@@ -164,7 +164,7 @@ func TestAlexaOnSessionStartedCalled(t *testing.T) {
 	handler := &emptyRequestHandler{}
 	alexa := getAlexaWithHandler(handler)
 	ctx := context.Background()
-	_, err := alexa.ProcessRequest(&ctx, request)
+	_, err := alexa.ProcessRequest(ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -175,7 +175,7 @@ func TestAlexaOnSessionStartedCalled(t *testing.T) {
 	handler = &emptyRequestHandler{}
 	alexa = getAlexaWithHandler(handler)
 	request.Session.New = true
-	_, err = alexa.ProcessRequest(&ctx, request)
+	_, err = alexa.ProcessRequest(ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -187,7 +187,7 @@ func TestAlexaOnSessionStartedCalled(t *testing.T) {
 	alexa = getAlexaWithHandler(handler)
 	request.Session.New = true
 	handler.OnSessionStartThrowsErr = true
-	_, err = alexa.ProcessRequest(&ctx, request)
+	_, err = alexa.ProcessRequest(ctx, request)
 	if !handler.OnSessionStartedCalled {
 		t.Error("On SessionStarted was not called for a new session.")
 	}
@@ -203,7 +203,7 @@ func TestAlexaOnLaunchCalled(t *testing.T) {
 	handler := &emptyRequestHandler{}
 	alexa := getAlexaWithHandler(handler)
 	ctx := context.Background()
-	_, err := alexa.ProcessRequest(&ctx, request)
+	_, err := alexa.ProcessRequest(ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -214,7 +214,7 @@ func TestAlexaOnLaunchCalled(t *testing.T) {
 	handler = &emptyRequestHandler{}
 	alexa = getAlexaWithHandler(handler)
 	handler.OnLaunchThrowsErr = true
-	_, err = alexa.ProcessRequest(&ctx, request)
+	_, err = alexa.ProcessRequest(ctx, request)
 	if !handler.OnLaunchCalled {
 		t.Error("OnLaunch was not called.")
 	}
@@ -230,7 +230,7 @@ func TestAlexaOnIntentCalled(t *testing.T) {
 	handler := &emptyRequestHandler{}
 	alexa := getAlexaWithHandler(handler)
 	ctx := context.Background()
-	_, err := alexa.ProcessRequest(&ctx, request)
+	_, err := alexa.ProcessRequest(ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -241,7 +241,7 @@ func TestAlexaOnIntentCalled(t *testing.T) {
 	handler = &emptyRequestHandler{}
 	alexa = getAlexaWithHandler(handler)
 	handler.OnIntentThrowsErr = true
-	_, err = alexa.ProcessRequest(&ctx, request)
+	_, err = alexa.ProcessRequest(ctx, request)
 	if !handler.OnIntentCalled {
 		t.Error("OnIntent was not called.")
 	}
@@ -258,7 +258,7 @@ func TestAlexaOnSessionEndedCalled(t *testing.T) {
 	alexa := getAlexaWithHandler(handler)
 
 	ctx := context.Background()
-	_, err := alexa.ProcessRequest(&ctx, request)
+	_, err := alexa.ProcessRequest(ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -269,7 +269,7 @@ func TestAlexaOnSessionEndedCalled(t *testing.T) {
 	handler = &emptyRequestHandler{}
 	alexa = getAlexaWithHandler(handler)
 	handler.OnSessionEndedThrowsErr = true
-	_, err = alexa.ProcessRequest(&ctx, request)
+	_, err = alexa.ProcessRequest(ctx, request)
 	if !handler.OnSessionEndedCalled {
 		t.Error("OnSessionEnded was not called.")
 	}
@@ -283,7 +283,7 @@ func TestAlexaSimpleTextResponse(t *testing.T) {
 
 	alexa := getAlexaWithHandler(&simpleResponseHandler{})
 	ctx := context.Background()
-	responseEnv, err := alexa.ProcessRequest(&ctx, request)
+	responseEnv, err := alexa.ProcessRequest(ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -308,7 +308,7 @@ func TestSimpleSSMLResponse(t *testing.T) {
 
 	alexa := getAlexaWithHandler(&simpleSSMLResponseHandler{})
 	ctx := context.Background()
-	responseEnv, err := alexa.ProcessRequest(&ctx, request)
+	responseEnv, err := alexa.ProcessRequest(ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -334,7 +334,7 @@ func TestCards(t *testing.T) {
 	cardHandler := &simpleCardResponseHandler{Type: "Simple"}
 	alexa := getAlexaWithHandler(cardHandler)
 	ctx := context.Background()
-	responseEnv, err := alexa.ProcessRequest(&ctx, request)
+	responseEnv, err := alexa.ProcessRequest(ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -346,7 +346,7 @@ func TestCards(t *testing.T) {
 	}
 
 	cardHandler.Type = "Standard"
-	responseEnv, err = alexa.ProcessRequest(&ctx, request)
+	responseEnv, err = alexa.ProcessRequest(ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -358,7 +358,7 @@ func TestCards(t *testing.T) {
 	}
 
 	cardHandler.Type = "LinkAccount"
-	responseEnv, err = alexa.ProcessRequest(&ctx, request)
+	responseEnv, err = alexa.ProcessRequest(ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -374,7 +374,7 @@ func TestAudioPlayer(t *testing.T) {
 	audioPlayerHandler := &simpleAudioPlayerResponseHandler{Type: "Simple"}
 	alexa := getAlexaWithHandler(audioPlayerHandler)
 	ctx := context.Background()
-	responseEnv, err := alexa.ProcessRequest(&ctx, request)
+	responseEnv, err := alexa.ProcessRequest(ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -399,7 +399,7 @@ func TestSimpleDialogDirective(t *testing.T) {
 	simpleDialogDirectiveResponseHandler := &simpleDialogDirectiveResponseHandler{Type: "Simple"}
 	alexa := getAlexaWithHandler(simpleDialogDirectiveResponseHandler)
 	ctx := context.Background()
-	responseEnv, err := alexa.ProcessRequest(&ctx, request)
+	responseEnv, err := alexa.ProcessRequest(ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -424,7 +424,7 @@ func TestNoIntentDialogDirective(t *testing.T) {
 	simpleDialogDirectiveResponseHandler := &simpleDialogDirectiveResponseHandler{Type: "NoIntent"}
 	alexa := getAlexaWithHandler(simpleDialogDirectiveResponseHandler)
 	ctx := context.Background()
-	responseEnv, err := alexa.ProcessRequest(&ctx, request)
+	responseEnv, err := alexa.ProcessRequest(ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -470,7 +470,7 @@ type emptyRequestHandler struct {
 	OnSessionEndedThrowsErr bool
 }
 
-func (h *emptyRequestHandler) OnSessionStarted(*context.Context, *Request, *Session, *Response) error {
+func (h *emptyRequestHandler) OnSessionStarted(context.Context, *Request, *Session, *Response) error {
 	h.OnSessionStartedCalled = true
 	if h.OnSessionStartThrowsErr {
 		return errors.New("Error in OnSessionStarted")
@@ -478,7 +478,7 @@ func (h *emptyRequestHandler) OnSessionStarted(*context.Context, *Request, *Sess
 	return nil
 }
 
-func (h *emptyRequestHandler) OnLaunch(*context.Context, *Request, *Session, *Response) error {
+func (h *emptyRequestHandler) OnLaunch(context.Context, *Request, *Session, *Response) error {
 	h.OnLaunchCalled = true
 	if h.OnLaunchThrowsErr {
 		return errors.New("Error in OnLaunch")
@@ -486,7 +486,7 @@ func (h *emptyRequestHandler) OnLaunch(*context.Context, *Request, *Session, *Re
 	return nil
 }
 
-func (h *emptyRequestHandler) OnIntent(*context.Context, *Request, *Session, *Response) error {
+func (h *emptyRequestHandler) OnIntent(context.Context, *Request, *Session, *Response) error {
 	h.OnIntentCalled = true
 	if h.OnIntentThrowsErr {
 		return errors.New("Error in OnIntent")
@@ -494,7 +494,7 @@ func (h *emptyRequestHandler) OnIntent(*context.Context, *Request, *Session, *Re
 	return nil
 }
 
-func (h *emptyRequestHandler) OnSessionEnded(*context.Context, *Request, *Session, *Response) error {
+func (h *emptyRequestHandler) OnSessionEnded(context.Context, *Request, *Session, *Response) error {
 	h.OnSessionEndedCalled = true
 	if h.OnSessionEndedThrowsErr {
 		return errors.New("Error in OnSessionEnded")
@@ -505,15 +505,15 @@ func (h *emptyRequestHandler) OnSessionEnded(*context.Context, *Request, *Sessio
 type simpleResponseHandler struct {
 }
 
-func (h *simpleResponseHandler) OnSessionStarted(*context.Context, *Request, *Session, *Response) error {
+func (h *simpleResponseHandler) OnSessionStarted(context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleResponseHandler) OnLaunch(*context.Context, *Request, *Session, *Response) error {
+func (h *simpleResponseHandler) OnLaunch(context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleResponseHandler) OnIntent(context *context.Context, request *Request, session *Session, response *Response) error {
+func (h *simpleResponseHandler) OnIntent(context context.Context, request *Request, session *Session, response *Response) error {
 
 	response.SetOutputText("Response Text")
 	response.SetRepromptText("Reprompt Text")
@@ -521,22 +521,22 @@ func (h *simpleResponseHandler) OnIntent(context *context.Context, request *Requ
 	return nil
 }
 
-func (h *simpleResponseHandler) OnSessionEnded(*context.Context, *Request, *Session, *Response) error {
+func (h *simpleResponseHandler) OnSessionEnded(context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
 type simpleSSMLResponseHandler struct {
 }
 
-func (h *simpleSSMLResponseHandler) OnSessionStarted(*context.Context, *Request, *Session, *Response) error {
+func (h *simpleSSMLResponseHandler) OnSessionStarted(context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleSSMLResponseHandler) OnLaunch(*context.Context, *Request, *Session, *Response) error {
+func (h *simpleSSMLResponseHandler) OnLaunch(context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleSSMLResponseHandler) OnIntent(context *context.Context, request *Request, session *Session, response *Response) error {
+func (h *simpleSSMLResponseHandler) OnIntent(context context.Context, request *Request, session *Session, response *Response) error {
 
 	response.SetOutputSSML("<speak>This output speech uses SSML.</speak>")
 	response.SetRepromptSSML("<speak>This Reprompt speech uses SSML.</speak>")
@@ -544,7 +544,7 @@ func (h *simpleSSMLResponseHandler) OnIntent(context *context.Context, request *
 	return nil
 }
 
-func (h *simpleSSMLResponseHandler) OnSessionEnded(*context.Context, *Request, *Session, *Response) error {
+func (h *simpleSSMLResponseHandler) OnSessionEnded(context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
@@ -552,15 +552,15 @@ type simpleCardResponseHandler struct {
 	Type string
 }
 
-func (h *simpleCardResponseHandler) OnSessionStarted(*context.Context, *Request, *Session, *Response) error {
+func (h *simpleCardResponseHandler) OnSessionStarted(context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleCardResponseHandler) OnLaunch(*context.Context, *Request, *Session, *Response) error {
+func (h *simpleCardResponseHandler) OnLaunch(context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleCardResponseHandler) OnIntent(context *context.Context, request *Request, session *Session, response *Response) error {
+func (h *simpleCardResponseHandler) OnIntent(context context.Context, request *Request, session *Session, response *Response) error {
 
 	switch h.Type {
 	case "Simple":
@@ -576,7 +576,7 @@ func (h *simpleCardResponseHandler) OnIntent(context *context.Context, request *
 	return nil
 }
 
-func (h *simpleCardResponseHandler) OnSessionEnded(*context.Context, *Request, *Session, *Response) error {
+func (h *simpleCardResponseHandler) OnSessionEnded(context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
@@ -584,22 +584,22 @@ type simpleAudioPlayerResponseHandler struct {
 	Type string
 }
 
-func (h *simpleAudioPlayerResponseHandler) OnSessionStarted(*context.Context, *Request, *Session, *Response) error {
+func (h *simpleAudioPlayerResponseHandler) OnSessionStarted(context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleAudioPlayerResponseHandler) OnLaunch(*context.Context, *Request, *Session, *Response) error {
+func (h *simpleAudioPlayerResponseHandler) OnLaunch(context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleAudioPlayerResponseHandler) OnIntent(context *context.Context, request *Request, session *Session, response *Response) error {
+func (h *simpleAudioPlayerResponseHandler) OnIntent(context context.Context, request *Request, session *Session, response *Response) error {
 
 	response.AddAudioPlayer("AudioPlayer.Play", "REPLACE_ALL", "track2-long-audio", "https://my-audio-hosting-site.com/audio/sample-song-2.mp3", 100)
 
 	return nil
 }
 
-func (h *simpleAudioPlayerResponseHandler) OnSessionEnded(*context.Context, *Request, *Session, *Response) error {
+func (h *simpleAudioPlayerResponseHandler) OnSessionEnded(context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
@@ -607,15 +607,15 @@ type simpleDialogDirectiveResponseHandler struct {
 	Type string
 }
 
-func (h *simpleDialogDirectiveResponseHandler) OnSessionStarted(*context.Context, *Request, *Session, *Response) error {
+func (h *simpleDialogDirectiveResponseHandler) OnSessionStarted(context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleDialogDirectiveResponseHandler) OnLaunch(*context.Context, *Request, *Session, *Response) error {
+func (h *simpleDialogDirectiveResponseHandler) OnLaunch(context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleDialogDirectiveResponseHandler) OnIntent(context *context.Context, request *Request, session *Session, response *Response) error {
+func (h *simpleDialogDirectiveResponseHandler) OnIntent(context context.Context, request *Request, session *Session, response *Response) error {
 
 	switch h.Type {
 	case "Simple":
@@ -638,6 +638,6 @@ func (h *simpleDialogDirectiveResponseHandler) OnIntent(context *context.Context
 	return nil
 }
 
-func (h *simpleDialogDirectiveResponseHandler) OnSessionEnded(*context.Context, *Request, *Session, *Response) error {
+func (h *simpleDialogDirectiveResponseHandler) OnSessionEnded(context.Context, *Request, *Session, *Response) error {
 	return nil
 }

--- a/alexa_test.go
+++ b/alexa_test.go
@@ -1,6 +1,7 @@
 package alexa
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -79,26 +80,27 @@ func TestAlexaAppIDValidation(t *testing.T) {
 	request := createRecipieRequest()
 
 	alexa := getAlexa()
-	_, err := alexa.ProcessRequest(request)
+	ctx := context.Background()
+	_, err := alexa.ProcessRequest(&ctx, request)
 	if err != nil {
 		t.Error("Expected ProcessRequest to succeed but got error", err)
 	}
 
 	alexa = &Alexa{ApplicationID: "amzn1.ask.skill.ABC123456", RequestHandler: &emptyRequestHandler{}}
-	_, err = alexa.ProcessRequest(request)
+	_, err = alexa.ProcessRequest(&ctx, request)
 	if err == nil {
 		t.Error("Expected ProcessRequest to fail due to invalid Application ID but no err was returned.")
 	}
 
 	alexa = &Alexa{ApplicationID: "", RequestHandler: &emptyRequestHandler{}}
-	_, err = alexa.ProcessRequest(request)
+	_, err = alexa.ProcessRequest(&ctx, request)
 	if err == nil {
 		t.Error("Expected ProcessRequest to fail due to an empty Application ID but no err was returned.")
 	}
 
 	alexa = &Alexa{ApplicationID: applicationID, RequestHandler: &emptyRequestHandler{}}
 	request.Session.Application.ApplicationID = ""
-	_, err = alexa.ProcessRequest(request)
+	_, err = alexa.ProcessRequest(&ctx, request)
 	if err == nil {
 		t.Error("Expected ProcessRequest to fail due to an empty Request Application ID but no err was returned.")
 	}
@@ -110,27 +112,28 @@ func TestAlexaTimestampValidation(t *testing.T) {
 	alexa := getAlexa()
 	duration, _ := time.ParseDuration("-145s")
 	request.Request.Timestamp = time.Now().Add(duration).Format(time.RFC3339)
-	_, err := alexa.ProcessRequest(request)
+	ctx := context.Background()
+	_, err := alexa.ProcessRequest(&ctx, request)
 	if err != nil {
 		t.Error("Expected ProcessRequest to succeed but got error", err)
 	}
 
 	duration, _ = time.ParseDuration("-151s")
 	request.Request.Timestamp = time.Now().Add(duration).Format(time.RFC3339)
-	_, err = alexa.ProcessRequest(request)
+	_, err = alexa.ProcessRequest(&ctx, request)
 	if err == nil {
 		t.Error("Expected ProcessRequest to fail to due to an invalid timetamp but no err was returned.")
 	}
 
 	duration, _ = time.ParseDuration("151s")
 	request.Request.Timestamp = time.Now().Add(duration).Format(time.RFC3339)
-	_, err = alexa.ProcessRequest(request)
+	_, err = alexa.ProcessRequest(&ctx, request)
 	if err == nil {
 		t.Error("Expected ProcessRequest to fail to due to an invalid timetamp but no err was returned.")
 	}
 
 	request.Request.Timestamp = "UNPARSEABLE"
-	_, err = alexa.ProcessRequest(request)
+	_, err = alexa.ProcessRequest(&ctx, request)
 	if err == nil {
 		t.Error("Expected ProcessRequest to fail because the timestamp could not be parsed but no err was returned")
 	}
@@ -138,7 +141,7 @@ func TestAlexaTimestampValidation(t *testing.T) {
 	alexa.SetTimestampTolerance(0)
 	duration, _ = time.ParseDuration("-1s")
 	request.Request.Timestamp = time.Now().Add(duration).Format(time.RFC3339)
-	_, err = alexa.ProcessRequest(request)
+	_, err = alexa.ProcessRequest(&ctx, request)
 	alexa.SetTimestampTolerance(150)
 	if err == nil {
 		t.Error("Expected ProcessRequest to fail to due to an invalid timetamp but no err was returned.")
@@ -148,7 +151,7 @@ func TestAlexaTimestampValidation(t *testing.T) {
 	duration, _ = time.ParseDuration("151s")
 	request.Request.Timestamp = time.Now().Add(duration).Format(time.RFC3339)
 	alexa.IgnoreTimestamp = true
-	_, err = alexa.ProcessRequest(request)
+	_, err = alexa.ProcessRequest(&ctx, request)
 	if err != nil {
 		t.Error("Expected ProcessRequest to pass even with an invalid timestamp because validation is disabled.")
 	}
@@ -160,7 +163,8 @@ func TestAlexaOnSessionStartedCalled(t *testing.T) {
 
 	handler := &emptyRequestHandler{}
 	alexa := getAlexaWithHandler(handler)
-	_, err := alexa.ProcessRequest(request)
+	ctx := context.Background()
+	_, err := alexa.ProcessRequest(&ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -171,7 +175,7 @@ func TestAlexaOnSessionStartedCalled(t *testing.T) {
 	handler = &emptyRequestHandler{}
 	alexa = getAlexaWithHandler(handler)
 	request.Session.New = true
-	_, err = alexa.ProcessRequest(request)
+	_, err = alexa.ProcessRequest(&ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -183,7 +187,7 @@ func TestAlexaOnSessionStartedCalled(t *testing.T) {
 	alexa = getAlexaWithHandler(handler)
 	request.Session.New = true
 	handler.OnSessionStartThrowsErr = true
-	_, err = alexa.ProcessRequest(request)
+	_, err = alexa.ProcessRequest(&ctx, request)
 	if !handler.OnSessionStartedCalled {
 		t.Error("On SessionStarted was not called for a new session.")
 	}
@@ -198,7 +202,8 @@ func TestAlexaOnLaunchCalled(t *testing.T) {
 
 	handler := &emptyRequestHandler{}
 	alexa := getAlexaWithHandler(handler)
-	_, err := alexa.ProcessRequest(request)
+	ctx := context.Background()
+	_, err := alexa.ProcessRequest(&ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -209,7 +214,7 @@ func TestAlexaOnLaunchCalled(t *testing.T) {
 	handler = &emptyRequestHandler{}
 	alexa = getAlexaWithHandler(handler)
 	handler.OnLaunchThrowsErr = true
-	_, err = alexa.ProcessRequest(request)
+	_, err = alexa.ProcessRequest(&ctx, request)
 	if !handler.OnLaunchCalled {
 		t.Error("OnLaunch was not called.")
 	}
@@ -224,7 +229,8 @@ func TestAlexaOnIntentCalled(t *testing.T) {
 
 	handler := &emptyRequestHandler{}
 	alexa := getAlexaWithHandler(handler)
-	_, err := alexa.ProcessRequest(request)
+	ctx := context.Background()
+	_, err := alexa.ProcessRequest(&ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -235,7 +241,7 @@ func TestAlexaOnIntentCalled(t *testing.T) {
 	handler = &emptyRequestHandler{}
 	alexa = getAlexaWithHandler(handler)
 	handler.OnIntentThrowsErr = true
-	_, err = alexa.ProcessRequest(request)
+	_, err = alexa.ProcessRequest(&ctx, request)
 	if !handler.OnIntentCalled {
 		t.Error("OnIntent was not called.")
 	}
@@ -250,7 +256,9 @@ func TestAlexaOnSessionEndedCalled(t *testing.T) {
 
 	handler := &emptyRequestHandler{}
 	alexa := getAlexaWithHandler(handler)
-	_, err := alexa.ProcessRequest(request)
+
+	ctx := context.Background()
+	_, err := alexa.ProcessRequest(&ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -261,7 +269,7 @@ func TestAlexaOnSessionEndedCalled(t *testing.T) {
 	handler = &emptyRequestHandler{}
 	alexa = getAlexaWithHandler(handler)
 	handler.OnSessionEndedThrowsErr = true
-	_, err = alexa.ProcessRequest(request)
+	_, err = alexa.ProcessRequest(&ctx, request)
 	if !handler.OnSessionEndedCalled {
 		t.Error("OnSessionEnded was not called.")
 	}
@@ -274,7 +282,8 @@ func TestAlexaSimpleTextResponse(t *testing.T) {
 	request := createRecipieRequest()
 
 	alexa := getAlexaWithHandler(&simpleResponseHandler{})
-	responseEnv, err := alexa.ProcessRequest(request)
+	ctx := context.Background()
+	responseEnv, err := alexa.ProcessRequest(&ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -298,7 +307,8 @@ func TestSimpleSSMLResponse(t *testing.T) {
 	request := createRecipieRequest()
 
 	alexa := getAlexaWithHandler(&simpleSSMLResponseHandler{})
-	responseEnv, err := alexa.ProcessRequest(request)
+	ctx := context.Background()
+	responseEnv, err := alexa.ProcessRequest(&ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -323,7 +333,8 @@ func TestCards(t *testing.T) {
 
 	cardHandler := &simpleCardResponseHandler{Type: "Simple"}
 	alexa := getAlexaWithHandler(cardHandler)
-	responseEnv, err := alexa.ProcessRequest(request)
+	ctx := context.Background()
+	responseEnv, err := alexa.ProcessRequest(&ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -335,7 +346,7 @@ func TestCards(t *testing.T) {
 	}
 
 	cardHandler.Type = "Standard"
-	responseEnv, err = alexa.ProcessRequest(request)
+	responseEnv, err = alexa.ProcessRequest(&ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -347,7 +358,7 @@ func TestCards(t *testing.T) {
 	}
 
 	cardHandler.Type = "LinkAccount"
-	responseEnv, err = alexa.ProcessRequest(request)
+	responseEnv, err = alexa.ProcessRequest(&ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -362,7 +373,8 @@ func TestAudioPlayer(t *testing.T) {
 
 	audioPlayerHandler := &simpleAudioPlayerResponseHandler{Type: "Simple"}
 	alexa := getAlexaWithHandler(audioPlayerHandler)
-	responseEnv, err := alexa.ProcessRequest(request)
+	ctx := context.Background()
+	responseEnv, err := alexa.ProcessRequest(&ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -386,7 +398,8 @@ func TestSimpleDialogDirective(t *testing.T) {
 
 	simpleDialogDirectiveResponseHandler := &simpleDialogDirectiveResponseHandler{Type: "Simple"}
 	alexa := getAlexaWithHandler(simpleDialogDirectiveResponseHandler)
-	responseEnv, err := alexa.ProcessRequest(request)
+	ctx := context.Background()
+	responseEnv, err := alexa.ProcessRequest(&ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -410,7 +423,8 @@ func TestNoIntentDialogDirective(t *testing.T) {
 
 	simpleDialogDirectiveResponseHandler := &simpleDialogDirectiveResponseHandler{Type: "NoIntent"}
 	alexa := getAlexaWithHandler(simpleDialogDirectiveResponseHandler)
-	responseEnv, err := alexa.ProcessRequest(request)
+	ctx := context.Background()
+	responseEnv, err := alexa.ProcessRequest(&ctx, request)
 	if err != nil {
 		t.Error("Error processing request. " + err.Error())
 	}
@@ -456,7 +470,7 @@ type emptyRequestHandler struct {
 	OnSessionEndedThrowsErr bool
 }
 
-func (h *emptyRequestHandler) OnSessionStarted(*Request, *Session, *Response) error {
+func (h *emptyRequestHandler) OnSessionStarted(*context.Context, *Request, *Session, *Response) error {
 	h.OnSessionStartedCalled = true
 	if h.OnSessionStartThrowsErr {
 		return errors.New("Error in OnSessionStarted")
@@ -464,7 +478,7 @@ func (h *emptyRequestHandler) OnSessionStarted(*Request, *Session, *Response) er
 	return nil
 }
 
-func (h *emptyRequestHandler) OnLaunch(*Request, *Session, *Response) error {
+func (h *emptyRequestHandler) OnLaunch(*context.Context, *Request, *Session, *Response) error {
 	h.OnLaunchCalled = true
 	if h.OnLaunchThrowsErr {
 		return errors.New("Error in OnLaunch")
@@ -472,7 +486,7 @@ func (h *emptyRequestHandler) OnLaunch(*Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *emptyRequestHandler) OnIntent(*Request, *Session, *Response) error {
+func (h *emptyRequestHandler) OnIntent(*context.Context, *Request, *Session, *Response) error {
 	h.OnIntentCalled = true
 	if h.OnIntentThrowsErr {
 		return errors.New("Error in OnIntent")
@@ -480,7 +494,7 @@ func (h *emptyRequestHandler) OnIntent(*Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *emptyRequestHandler) OnSessionEnded(*Request, *Session, *Response) error {
+func (h *emptyRequestHandler) OnSessionEnded(*context.Context, *Request, *Session, *Response) error {
 	h.OnSessionEndedCalled = true
 	if h.OnSessionEndedThrowsErr {
 		return errors.New("Error in OnSessionEnded")
@@ -491,15 +505,15 @@ func (h *emptyRequestHandler) OnSessionEnded(*Request, *Session, *Response) erro
 type simpleResponseHandler struct {
 }
 
-func (h *simpleResponseHandler) OnSessionStarted(*Request, *Session, *Response) error {
+func (h *simpleResponseHandler) OnSessionStarted(*context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleResponseHandler) OnLaunch(*Request, *Session, *Response) error {
+func (h *simpleResponseHandler) OnLaunch(*context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleResponseHandler) OnIntent(request *Request, session *Session, response *Response) error {
+func (h *simpleResponseHandler) OnIntent(context *context.Context, request *Request, session *Session, response *Response) error {
 
 	response.SetOutputText("Response Text")
 	response.SetRepromptText("Reprompt Text")
@@ -507,22 +521,22 @@ func (h *simpleResponseHandler) OnIntent(request *Request, session *Session, res
 	return nil
 }
 
-func (h *simpleResponseHandler) OnSessionEnded(*Request, *Session, *Response) error {
+func (h *simpleResponseHandler) OnSessionEnded(*context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
 type simpleSSMLResponseHandler struct {
 }
 
-func (h *simpleSSMLResponseHandler) OnSessionStarted(*Request, *Session, *Response) error {
+func (h *simpleSSMLResponseHandler) OnSessionStarted(*context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleSSMLResponseHandler) OnLaunch(*Request, *Session, *Response) error {
+func (h *simpleSSMLResponseHandler) OnLaunch(*context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleSSMLResponseHandler) OnIntent(request *Request, session *Session, response *Response) error {
+func (h *simpleSSMLResponseHandler) OnIntent(context *context.Context, request *Request, session *Session, response *Response) error {
 
 	response.SetOutputSSML("<speak>This output speech uses SSML.</speak>")
 	response.SetRepromptSSML("<speak>This Reprompt speech uses SSML.</speak>")
@@ -530,7 +544,7 @@ func (h *simpleSSMLResponseHandler) OnIntent(request *Request, session *Session,
 	return nil
 }
 
-func (h *simpleSSMLResponseHandler) OnSessionEnded(*Request, *Session, *Response) error {
+func (h *simpleSSMLResponseHandler) OnSessionEnded(*context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
@@ -538,15 +552,15 @@ type simpleCardResponseHandler struct {
 	Type string
 }
 
-func (h *simpleCardResponseHandler) OnSessionStarted(*Request, *Session, *Response) error {
+func (h *simpleCardResponseHandler) OnSessionStarted(*context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleCardResponseHandler) OnLaunch(*Request, *Session, *Response) error {
+func (h *simpleCardResponseHandler) OnLaunch(*context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleCardResponseHandler) OnIntent(request *Request, session *Session, response *Response) error {
+func (h *simpleCardResponseHandler) OnIntent(context *context.Context, request *Request, session *Session, response *Response) error {
 
 	switch h.Type {
 	case "Simple":
@@ -562,7 +576,7 @@ func (h *simpleCardResponseHandler) OnIntent(request *Request, session *Session,
 	return nil
 }
 
-func (h *simpleCardResponseHandler) OnSessionEnded(*Request, *Session, *Response) error {
+func (h *simpleCardResponseHandler) OnSessionEnded(*context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
@@ -570,22 +584,22 @@ type simpleAudioPlayerResponseHandler struct {
 	Type string
 }
 
-func (h *simpleAudioPlayerResponseHandler) OnSessionStarted(*Request, *Session, *Response) error {
+func (h *simpleAudioPlayerResponseHandler) OnSessionStarted(*context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleAudioPlayerResponseHandler) OnLaunch(*Request, *Session, *Response) error {
+func (h *simpleAudioPlayerResponseHandler) OnLaunch(*context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleAudioPlayerResponseHandler) OnIntent(request *Request, session *Session, response *Response) error {
+func (h *simpleAudioPlayerResponseHandler) OnIntent(context *context.Context, request *Request, session *Session, response *Response) error {
 
 	response.AddAudioPlayer("AudioPlayer.Play", "REPLACE_ALL", "track2-long-audio", "https://my-audio-hosting-site.com/audio/sample-song-2.mp3", 100)
 
 	return nil
 }
 
-func (h *simpleAudioPlayerResponseHandler) OnSessionEnded(*Request, *Session, *Response) error {
+func (h *simpleAudioPlayerResponseHandler) OnSessionEnded(*context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
@@ -593,15 +607,15 @@ type simpleDialogDirectiveResponseHandler struct {
 	Type string
 }
 
-func (h *simpleDialogDirectiveResponseHandler) OnSessionStarted(*Request, *Session, *Response) error {
+func (h *simpleDialogDirectiveResponseHandler) OnSessionStarted(*context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleDialogDirectiveResponseHandler) OnLaunch(*Request, *Session, *Response) error {
+func (h *simpleDialogDirectiveResponseHandler) OnLaunch(*context.Context, *Request, *Session, *Response) error {
 	return nil
 }
 
-func (h *simpleDialogDirectiveResponseHandler) OnIntent(request *Request, session *Session, response *Response) error {
+func (h *simpleDialogDirectiveResponseHandler) OnIntent(context *context.Context, request *Request, session *Session, response *Response) error {
 
 	switch h.Type {
 	case "Simple":
@@ -624,6 +638,6 @@ func (h *simpleDialogDirectiveResponseHandler) OnIntent(request *Request, sessio
 	return nil
 }
 
-func (h *simpleDialogDirectiveResponseHandler) OnSessionEnded(*Request, *Session, *Response) error {
+func (h *simpleDialogDirectiveResponseHandler) OnSessionEnded(*context.Context, *Request, *Session, *Response) error {
 	return nil
 }


### PR DESCRIPTION
Pass along the context sent into the Handler to allow us to pass it along to other APIs that take a context as a parameter. Allow for propagating cancellation etc.