### PR TITLE
Multi value slots

### DIFF
--- a/alexa.go
+++ b/alexa.go
@@ -119,7 +119,7 @@ type IntentSlot struct {
 
 	// SlotValue is a BETA field and may be removed by Amazon without warning.
 	// See https://developer.amazon.com/en-US/docs/alexa/custom-skills/collect-multiple-values-in-a-slot.html.
-	SlotValue *IntentSlotValue `json:"slotValue"`
+	SlotValue *IntentSlotValue `json:"slotValue,omitempty"`
 }
 
 // IntentSlotValue contains the value or values of a slot.

--- a/alexa.go
+++ b/alexa.go
@@ -112,24 +112,24 @@ type Intent struct {
 
 // IntentSlot contains the data for one Slot
 type IntentSlot struct {
-	Name               string `json:"name"`
-	ConfirmationStatus string `json:"confirmationStatus,omitempty"`
-	SlotValue   *IntentSlotValue `json:"slotValue"`
+	Name               string       `json:"name"`
+	ConfirmationStatus string       `json:"confirmationStatus,omitempty"`
+	Value              string       `json:"value"`
+	Resolutions        *Resolutions `json:"resolutions,omitempty"`
 
-	// Deprecated: use SlotValue.Value instead
-	Value string `json:"value"`
-	// Deprecated: use SlotValue.Resolutions instead
-	Resolutions *Resolutions     `json:"resolutions,omitempty"`
+	// SlotValue is a BETA field and may be removed by Amazon without warning.
+	// See https://developer.amazon.com/en-US/docs/alexa/custom-skills/collect-multiple-values-in-a-slot.html.
+	SlotValue *IntentSlotValue `json:"slotValue"`
 }
 
 // IntentSlotValue contains the value or values of a slot.
 // When Type == "Simple", Value and Resolutions are populated.
 // When Type == "List", Values is populated.
 type IntentSlotValue struct {
-	Type string `json:"type"`
-	Values []*IntentSlotValue `json:"values"`
-	Value string `json:"value"`
-	Resolutions *Resolutions `json:"resolutions,omitempty"`
+	Type        string             `json:"type"`
+	Values      []*IntentSlotValue `json:"values"`
+	Value       string             `json:"value"`
+	Resolutions *Resolutions       `json:"resolutions,omitempty"`
 }
 
 // Resolutions contain the (optional) ID of a slot

--- a/alexa.go
+++ b/alexa.go
@@ -112,10 +112,24 @@ type Intent struct {
 
 // IntentSlot contains the data for one Slot
 type IntentSlot struct {
-	Name               string       `json:"name"`
-	ConfirmationStatus string       `json:"confirmationStatus,omitempty"`
-	Value              string       `json:"value"`
-	Resolutions        *Resolutions `json:"resolutions,omitempty"`
+	Name               string `json:"name"`
+	ConfirmationStatus string `json:"confirmationStatus,omitempty"`
+	SlotValue   *IntentSlotValue `json:"slotValue"`
+
+	// Deprecated: use SlotValue.Value instead
+	Value string `json:"value"`
+	// Deprecated: use SlotValue.Resolutions instead
+	Resolutions *Resolutions     `json:"resolutions,omitempty"`
+}
+
+// IntentSlotValue contains the value or values of a slot.
+// When Type == "Simple", Value and Resolutions are populated.
+// When Type == "List", Values is populated.
+type IntentSlotValue struct {
+	Type string `json:"type"`
+	Values []*IntentSlotValue `json:"values"`
+	Value string `json:"value"`
+	Resolutions *Resolutions `json:"resolutions,omitempty"`
 }
 
 // Resolutions contain the (optional) ID of a slot


### PR DESCRIPTION
The [multi-value slots](https://developer.amazon.com/en-US/docs/alexa/custom-skills/collect-multiple-values-in-a-slot.html) beta feature modifies the slot json to add a new field: `slotValues`. 

The field is populated and can be used regardless of whether the beta feature is enabled. That said, the field is not listed in the [official documentation](https://developer.amazon.com/en-US/docs/alexa/custom-skills/request-types-reference.html#intentrequest) for IntentRequest--it is referenced only in the beta feature page.

I'm making this PR because I needed this feature in a skill. But I certainly understand not wanting to pull a beta feature in and thus declining this PR.